### PR TITLE
Create Local System Connector

### DIFF
--- a/ConnectToLocalSystem.go
+++ b/ConnectToLocalSystem.go
@@ -1,0 +1,16 @@
+package goVirtQemuConnector
+
+import "libvirt.org/go/libvirt"
+
+// Connect to local Qemu socket. This function should be called first to get a connection to the Hypervisor.
+// ConnectToLocalSystem().close() should be used to release the resources after the connection is no longer
+// needed.
+func ConnectToLocalSystem() (*libvirt.Connect, error) {
+	result, errorResult := libvirt.NewConnect("qemu:///system")
+	if errorResult != nil {
+		return nil, errorResult
+	}
+	defer result.Close()
+
+	return result, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/Hari-Kiri/govirt-qemu-connector
 
 go 1.23.0
+
+require libvirt.org/go/libvirt v1.10008.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+libvirt.org/go/libvirt v1.10008.0 h1:j+hybvOmBQFC2BiivOVCPE3ozpQWtxWXp9p1cGk0x1Y=
+libvirt.org/go/libvirt v1.10008.0/go.mod h1:1WiFE8EjZfq+FCVog+rvr1yatKbKZ9FaFMZgEqxEJqQ=


### PR DESCRIPTION
Connect to local Qemu socket. This function should be called first to get a connection to the Hypervisor. ConnectToLocalSystem().close() should be used to release the resources after the connection is no longer needed.